### PR TITLE
keyboard input: support alt/shift/ctrl modifiers

### DIFF
--- a/examples/postprocessing.rs
+++ b/examples/postprocessing.rs
@@ -186,6 +186,9 @@ pub fn main() {
                                 "KeyW" => eye = eye - front * 2.0,
                                 "KeyS" => eye = eye + front * 2.0,
                                 "Escape" => game.reset(),
+                                "Enter" => if key.alt {
+                                    println!("ALT-ENTER");
+                                },
                                 _ => (),
                             };
                         }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,6 @@ pub use self::imgui::Metric;
 pub use self::render::*;
 pub use self::asset::*;
 pub use self::core::{Component, ComponentBased, GameObject};
-pub use self::engine::{IEngine,ClearOption};
+pub use self::engine::{ClearOption, IEngine};
 
 pub type Engine<FS, F> = engine::Engine<AssetDatabase<FS, F>>;

--- a/uni-app/src/lib.rs
+++ b/uni-app/src/lib.rs
@@ -49,12 +49,17 @@ impl AppConfig {
 }
 
 mod events {
+    use std::fmt;
+
     #[derive(Debug, Clone)]
     pub struct ClickEvent;
 
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     pub struct KeyDownEvent {
         pub code: String,
+        pub shift: bool,
+        pub alt: bool,
+        pub ctrl: bool,
     }
 
     #[derive(Debug, Clone)]
@@ -62,10 +67,40 @@ mod events {
         pub code: String,
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     pub struct KeyUpEvent {
         pub code: String,
+        pub shift: bool,
+        pub alt: bool,
+        pub ctrl: bool,
     }
+
+    impl fmt::Debug for KeyUpEvent {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "{} {} {} {}",
+                if self.shift { "shift" } else { "" },
+                if self.alt { "alt" } else { "" },
+                if self.ctrl { "ctrl" } else { "" },
+                self.code,
+            )
+        }
+    }
+
+    impl fmt::Debug for KeyDownEvent {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "{} {} {} {}",
+                if self.shift { "shift" } else { "" },
+                if self.alt { "alt" } else { "" },
+                if self.ctrl { "ctrl" } else { "" },
+                self.code,
+            )
+        }
+    }
+
 }
 
 pub use events::*;

--- a/uni-app/src/native_app.rs
+++ b/uni-app/src/native_app.rs
@@ -45,9 +45,15 @@ fn translate_event(e: glutin::Event) -> Option<AppEvent> {
             WindowEvent::KeyboardInput { input, .. } => match input.state {
                 ElementState::Pressed => Some(AppEvent::KeyDown(events::KeyDownEvent {
                     code: translate_keyevent(input),
+                    shift: input.modifiers.shift,
+                    alt: input.modifiers.alt,
+                    ctrl: input.modifiers.ctrl,
                 })),
                 ElementState::Released => Some(AppEvent::KeyUp(events::KeyUpEvent {
                     code: translate_keyevent(input),
+                    shift: input.modifiers.shift,
+                    alt: input.modifiers.alt,
+                    ctrl: input.modifiers.ctrl,
                 })),
             },
             WindowEvent::Resized(w, h) => Some(AppEvent::Resized((w, h))),

--- a/uni-app/src/web_app.rs
+++ b/uni-app/src/web_app.rs
@@ -7,6 +7,7 @@ use stdweb::web::event::{ClickEvent, IKeyboardEvent, KeyDownEvent, KeyUpEvent, R
 use stdweb::unstable::TryInto;
 use stdweb::web::html_element::CanvasElement;
 use stdweb::web::IHtmlElement;
+use stdweb::traits::IEvent;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -26,6 +27,7 @@ macro_rules! map_event {
         {
             let events = $events.clone();
             move |$ee: $x| {
+                $ee.prevent_default();
                 events.borrow_mut().push(AppEvent::$y($e));
             }
         }
@@ -106,7 +108,10 @@ impl App {
             KeyDown,
             e,
             events::KeyDownEvent {
-                code: e.code()
+                code: e.code(),
+                shift: e.shift_key(),
+                alt: e.alt_key(),
+                ctrl: e.ctrl_key(),
             }
         });
 
@@ -126,7 +131,10 @@ impl App {
             KeyUp,
             e,
             events::KeyUpEvent {
-                code: e.code()
+                code: e.code(),
+                shift: e.shift_key(),
+                alt: e.alt_key(),
+                ctrl: e.ctrl_key(),
             }
         });
 


### PR DESCRIPTION
also prevent key events to bubble up to browser so that the game can use keys like TAB, F5, ...