### PR TITLE
upgrade opengl to 3.2. fix #18

### DIFF
--- a/uni-app/src/native_app.rs
+++ b/uni-app/src/native_app.rs
@@ -75,7 +75,7 @@ impl App {
         let context = glutin::ContextBuilder::new()
             .with_vsync(config.vsync)
             .with_gl(GlRequest::GlThenGles {
-                opengl_version: (3, 1),
+                opengl_version: (3, 2),
                 opengles_version: (2, 0),
             });
         let gl_window = glutin::GlWindow::new(window, context, &events_loop).unwrap();

--- a/uni-app/src/web_app.rs
+++ b/uni-app/src/web_app.rs
@@ -160,7 +160,7 @@ impl App {
 }
 
 pub fn now() -> f64 {
-    let v = js! { return performance.now(); };
+    let v = js! { return performance.now()/1000.0; };
     return v.try_into().unwrap();
 }
 


### PR DESCRIPTION
This also fixes an inconsistency in now() function. It was returning seconds in native and milliseconds on web.