### PR TITLE
Some features for webgl/uni-app

### DIFF
--- a/uni-app/src/lib.rs
+++ b/uni-app/src/lib.rs
@@ -36,6 +36,7 @@ pub struct AppConfig {
     pub title: String,
     pub size: (u32, u32),
     pub vsync: bool,
+    pub show_cursor: bool,
 }
 
 impl AppConfig {
@@ -44,6 +45,7 @@ impl AppConfig {
             title: title.into(),
             size,
             vsync: true,
+            show_cursor: true,
         }
     }
 }

--- a/uni-app/src/lib.rs
+++ b/uni-app/src/lib.rs
@@ -111,4 +111,5 @@ pub enum AppEvent {
     KeyDown(KeyDownEvent),
     KeyUp(KeyUpEvent),
     Resized((u32, u32)),
+    MousePos((f64, f64)),
 }

--- a/uni-app/src/native_app.rs
+++ b/uni-app/src/native_app.rs
@@ -42,6 +42,7 @@ fn translate_event(e: glutin::Event) -> Option<AppEvent> {
             WindowEvent::MouseInput { state, .. } if state == ElementState::Released => {
                 Some(AppEvent::Click(events::ClickEvent {}))
             }
+            WindowEvent::CursorMoved { position, .. } => Some(AppEvent::MousePos(position)),
             WindowEvent::KeyboardInput { input, .. } => match input.state {
                 ElementState::Pressed => Some(AppEvent::KeyDown(events::KeyDownEvent {
                     code: translate_keyevent(input),

--- a/uni-app/src/native_app.rs
+++ b/uni-app/src/native_app.rs
@@ -82,7 +82,9 @@ impl App {
             .with_gl_profile(GlProfile::Core);
 
         let gl_window = glutin::GlWindow::new(window, context, &events_loop).unwrap();
-
+        if !config.show_cursor {
+            gl_window.set_cursor_state(CursorState::Hide).unwrap();
+        }
         unsafe {
             gl_window.make_current().unwrap();
         }

--- a/uni-app/src/native_app.rs
+++ b/uni-app/src/native_app.rs
@@ -5,6 +5,7 @@ use std::os::raw::c_void;
 use glutin::{ElementState, Event, WindowEvent};
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::env;
 use time;
 
 use AppConfig;
@@ -94,6 +95,12 @@ impl App {
             exiting: false,
             events: Rc::new(RefCell::new(Vec::new())),
         }
+    }
+
+    pub fn get_params() -> Vec<String> {
+        let mut params: Vec<String> = env::args().collect();
+        params.remove(0);
+        params
     }
 
     pub fn print<T: Into<String>>(msg: T) {

--- a/uni-app/src/web_app.rs
+++ b/uni-app/src/web_app.rs
@@ -61,6 +61,11 @@ impl App {
             // https://stackoverflow.com/questions/12886286/addeventlistener-for-keydown-on-canvas
             @{&canvas}.tabIndex = 1;
         };
+        if !config.show_cursor {
+            js! {
+                @{&canvas}.style.cursor="none";
+            };
+        }
 
         document()
             .query_selector("body")

--- a/uni-app/src/web_app.rs
+++ b/uni-app/src/web_app.rs
@@ -3,7 +3,7 @@ use AppConfig;
 
 use stdweb::web::IEventTarget;
 use stdweb::web::window;
-use stdweb::web::event::{ClickEvent, IKeyboardEvent, KeyDownEvent, KeyUpEvent, ResizeEvent};
+use stdweb::web::event::{ClickEvent, IKeyboardEvent, IMouseEvent, MouseMoveEvent, KeyDownEvent, KeyUpEvent, ResizeEvent};
 use stdweb::unstable::TryInto;
 use stdweb::web::html_element::CanvasElement;
 use stdweb::web::IHtmlElement;
@@ -114,6 +114,21 @@ impl App {
             events::ClickEvent {}
         });
 
+        canvas.add_event_listener({
+            let canvas = canvas.clone();
+            let canvas_x : f64 = js! {
+                return @{&canvas}.getBoundingClientRect().left; }.try_into().unwrap();
+            let canvas_y : f64 = js! {
+                return @{&canvas}.getBoundingClientRect().top; }.try_into().unwrap();
+            map_event!{
+                self.events,
+                MouseMoveEvent,
+                MousePos,
+                e,
+                (e.client_x() as f64 - canvas_x,e.client_y() as f64 - canvas_y)
+            }
+        });
+        
         canvas.add_event_listener(map_event!{
             self.events,
             KeyDownEvent,

--- a/uni-app/src/web_app.rs
+++ b/uni-app/src/web_app.rs
@@ -82,6 +82,11 @@ impl App {
         js!{ console.log(@{msg.into()})};
     }
 
+    pub fn get_params() -> Vec<String> {
+        let params = js!{ return window.location.search.substring(1).split("&"); };
+        params.try_into().unwrap()
+    }
+
     pub fn hidpi_factor(&self) -> f32 {
         return 1.0;
     }

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -676,6 +676,14 @@ impl GLContext {
         }
     }
 
+    pub fn uniform_1fv(&self, location: &WebGLUniformLocation, count: usize, value: &[f32]) {
+        js!{
+            var ctx = Module.gl.get(@{self.reference});
+            var loc = Module.gl.get(@{location.deref()});
+            ctx.uniformMatrix1fv(loc,false,@{value})
+        }
+    }
+
     pub fn uniform_1i(&self, location: &WebGLUniformLocation, value: i32) {
         js!{
             var ctx = Module.gl.get(@{self.reference});

--- a/webgl/src/webgl_native.rs
+++ b/webgl/src/webgl_native.rs
@@ -579,48 +579,63 @@ impl GLContext {
         unsafe {
             gl::UniformMatrix4fv(*location.deref() as i32, 1, false as _, &value[0] as _);
         }
+        check_gl_error("uniform_matrix_4fv");
     }
 
     pub fn uniform_matrix_3fv(&self, location: &WebGLUniformLocation, value: &[[f32; 3]; 3]) {
         unsafe {
             gl::UniformMatrix3fv(*location.deref() as i32, 1, false as _, &value[0] as _);
         }
+        check_gl_error("uniform_matrix_3fv");
     }
 
     pub fn uniform_matrix_2fv(&self, location: &WebGLUniformLocation, value: &[[f32; 2]; 2]) {
         unsafe {
             gl::UniformMatrix2fv(*location.deref() as i32, 1, false as _, &value[0] as _);
         }
+        check_gl_error("uniform_matrix_2fv");
+    }
+
+    pub fn uniform_1fv(&self, location: &WebGLUniformLocation, count: usize, value: &[f32]) {
+        unsafe {
+            gl::Uniform1fv(*location.deref() as i32, count as i32, &value[0] as _);
+        }
+        check_gl_error("uniform_1fv");
     }
 
     pub fn uniform_1i(&self, location: &WebGLUniformLocation, value: i32) {
         unsafe {
             gl::Uniform1i(*location.deref() as i32, value as _);
         }
+        check_gl_error("uniform_1i");
     }
 
     pub fn uniform_1f(&self, location: &WebGLUniformLocation, value: f32) {
         unsafe {
             gl::Uniform1f(*location.deref() as i32, value as _);
         }
+        check_gl_error("uniform_1f");
     }
 
     pub fn uniform_2f(&self, location: &WebGLUniformLocation, value: (f32, f32)) {
         unsafe {
             gl::Uniform2f(*location.deref() as _, value.0, value.1);
         }
+        check_gl_error("uniform_2f");
     }
 
     pub fn uniform_3f(&self, location: &WebGLUniformLocation, value: (f32, f32, f32)) {
         unsafe {
             gl::Uniform3f(*location.deref() as _, value.0, value.1, value.2);
         }
+        check_gl_error("uniform_3f");
     }
 
     pub fn uniform_4f(&self, location: &WebGLUniformLocation, value: (f32, f32, f32, f32)) {
         unsafe {
             gl::Uniform4f(*location.deref() as _, value.0, value.1, value.2, value.3);
         }
+        check_gl_error("uniform_4f");
     }
 
     pub fn tex_parameteri(&self, kind: TextureKind, pname: TextureParameter, param: i32) {


### PR DESCRIPTION
- possibility to hide mouse cursor with uni-app::AppConfig.show_cursor=false

- uni-app::AppEvent::MousePos event

- added webgl::uniform_1fv

They work fine on native. Can't test the web part right now as wasm target is broken on nightly