### PR TITLE
add uni-snd : low level sound layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "alga"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,9 +22,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "android_glue"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "approx"
@@ -24,9 +49,38 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "atty"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bindgen"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -49,6 +103,14 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cexpr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +122,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -103,6 +189,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coreaudio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cpal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "alsa-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coreaudio-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deflate"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +247,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -210,6 +336,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "glutin"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +405,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -281,6 +417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libloading"
@@ -326,6 +472,14 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -463,6 +617,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
 version = "4.0.0-beta2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -551,6 +713,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +785,34 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 
@@ -674,6 +869,11 @@ dependencies = [
 
 [[package]]
 name = "stdweb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stdweb"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -709,6 +909,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +933,33 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -751,6 +983,11 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uni-app"
 version = "0.1.0"
 dependencies = [
@@ -768,9 +1005,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "uni-snd"
+version = "0.1.0"
+dependencies = [
+ "cpal 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uni-app 0.1.0",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unrust"
@@ -786,8 +1045,24 @@ dependencies = [
  "obj 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uni-app 0.1.0",
  "uni-glsl 0.1.0",
+ "uni-snd 0.1.0",
  "webgl 0.1.0",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wayland-client"
@@ -863,6 +1138,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,24 +1215,36 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum alga 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "49d80afe08c2e8075d33d3ba01e9f7b0c16c20bebdf1f73df805c4ee862cf8a9"
+"checksum alsa-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9013f855a808ab924a4c08b5c1ec9bd6b04fdb2295b4d570fb723e0ed2802a4f"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum base-x 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f59103b47307f76e03bef1633aec7fa9e29bfb5aa6daf5a334f94233c71f6c1"
+"checksum bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b242e11a8f446f5fc7b76b37e81d737cabca562a927bd33766dac55b5f1177f"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum cc 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fedf677519ac9e865c4ff43ef8f930773b37ed6e6ea61b6b83b400a7b5787f49"
+"checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
+"checksum clang-sys 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e414af9726e1d11660801e73ccc7fb81803fb5f49e5903a25b348b2b3b480d2e"
+"checksum clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dc18f6f4005132120d9711636b32c46a233fad94df6217fa1d81c5e97a9f200"
 "checksum cocoa 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0c23085dde1ef4429df6e5896b89356d35cdd321fb43afe3e378d010bb5adc6"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum core-graphics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb0ed45fdc32f9ab426238fba9407dfead7bacd7900c9b4dd3f396f46eafdae3"
+"checksum coreaudio-rs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0542568ebe1136d8be7a9032541441d85c2654c230d41499d0c79d74b983209a"
+"checksum coreaudio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3514bd984efbc6e996748f139fcbadb00c564533b1a28bebdf9895441befeaa6"
+"checksum cpal 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d055e358040f5ab5fa90bc69f7c87ad4532578c3d4fcbf8261db2f2c5f5f9541"
 "checksum deflate 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4dddda59aaab719767ab11d3efd9a714e95b610c4445d4435765021e9d52dfb1"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -960,20 +1255,24 @@ dependencies = [
 "checksum gl_generator 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "75d69f914b49d9ff32fdf394cbd798f8c716d74fd19f9cc29da3e99797b2a78d"
 "checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9997e65a2cfec0f3290a8378652e3aacdb3f19d29a7ca20c11e11ca550eec9"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glutin 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90de8e0391e57098acfbfe693b23065e9186255d370ebae12c933b7d77df8424"
 "checksum image 0.18.0 (git+https://github.com/edwin0cheng/image?branch=impl_tga_read_scanline)" = "<none>"
 "checksum inflate 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f5f9f47468e9a76a6452271efadc88fe865a82be91fe75e6c0c57b87ccea59d4"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9ef23fcc4059260c5936f638c9805ebfc87cb172fa6661d130cba7f97d58f55"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)" = "f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff"
+"checksum libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum matrixmultiply 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cac1a66eab356036af85ea093101a14223dc6e3f4c02a59b7d572e5b93270bf7"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum nalgebra 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8516d8710f28c64cfc75b274c75c55c967ad4ece7090521b3c065de1d12336b"
@@ -985,6 +1284,7 @@ dependencies = [
 "checksum ncollide_transformation 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "348a4684b4e409f0e4b9d649afa4460a09fcefc6083113a1483008db8ada8845"
 "checksum ncollide_utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0bf88903f5ee3f6e1c2a86e3aaff81d8fb4315ee4ccb52ff70cdd0fdbf0425"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum nom 4.0.0-beta2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b86dd5a5739ba63d5e7e1ec90806c4c13a5fb1ea8b8855e2e3796d821627301"
 "checksum nphysics3d 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "723137babde11a7738f199ee66d7450f0aaf8227fb2975a18144d3b2466ea1bb"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
@@ -996,6 +1296,7 @@ dependencies = [
 "checksum obj 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d45c2c3901186c6f00e41772142d7f036a724b23d469dad93be0bded86acea2d"
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
@@ -1005,27 +1306,42 @@ dependencies = [
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum serde 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4d6340aa5fcdac490a1aa3511ff079b1cdaa45ffb766b2fd83395dae085cd5"
 "checksum serde_derive 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c7e2a9833bb397a3284b55e208b895e2486b8e6c6682a428e309204cd9d75a"
 "checksum serde_derive_internals 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc848d073be32cd982380c06587ea1d433bc1a4c4a111de07ec2286a3ddade8"
 "checksum serde_json 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fab6c4d75bedcf880711c85e39ebf8ccc70d0eba259899047ec5d7436643ee17"
 "checksum shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8254bf098ce4d8d7cc7cc6de438c5488adc5297e5b7ffef88816c0a91bd289c1"
+"checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
 "checksum stdweb 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd1acfdd499655f9aec6078e5cbb36a4cae3cb5235fd6fff572ca82b63b9d97f"
 "checksum stdweb-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa46e9b38ea028a8a327ae6db35a486ace3eb834f5600bb3b6a71c0b6b1bd4b"
 "checksum stdweb-internal-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0bb3289dfd46bba44d80ed47a9b3d4c43bf6c1d7931b29e2fa86bd6697ccf59"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8c5bc2d6ff27891209efa5f63e9de78648d7801f085e4653701a692ce938d6fd"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2b90adf943117ee4930d7944fe103dcb6f36ba05421f46521cb5adbf6bf0fbc8"
 "checksum wayland-kbd 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe0fb1c9917da9529d781659e456d84a693d74fe873d1658109758444616f76"
 "checksum wayland-protocols 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb5942dd2fc79d934db437c9ea3aabffceb49b546046ea453bcba531005e5537"
 "checksum wayland-scanner 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dcffa55a621e6f2c3d436de64d840fc325e1d0a467b92ee5e7292e17552e08ad"
 "checksum wayland-sys 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "377a2f83063c463e801ca10ae8cb9666e6e597eecac0049ac36cc7b9a83b0db3"
 "checksum wayland-window 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d94d3c23f8f2e0a09d82c6ca765da3c1efe65ef0280f750d74a6c6c6bb4ca8f"
+"checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ ncollide = "0.13.0"
 webgl = {path="webgl"}
 uni-app = {path="uni-app"}
 uni-glsl = {path="uni-glsl"}
+uni-snd = {path="uni-snd"}
 futures = "0.1"
 obj = "0.8.2"
 alga = "0.5"

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -1,0 +1,111 @@
+extern crate uni_app;
+extern crate uni_snd;
+extern crate unrust;
+
+use uni_app::App;
+use uni_snd::{SoundDriver, SoundGenerator};
+
+use unrust::world::{Actor, Camera, World, WorldBuilder};
+use unrust::engine::GameObject;
+use unrust::world::events::AppEvent;
+
+// GUI
+use unrust::imgui;
+
+struct SinGenerator {
+    sample_rate: f32,
+    frequency: f32,
+    i: usize,
+    channel: usize,
+    volume: f32,
+}
+
+impl SinGenerator {
+    pub fn new(volume: f32) -> Self {
+        Self {
+            sample_rate: 44000.0,
+            frequency: 440.0,
+            i: 0,
+            channel: 0,
+            volume,
+        }
+    }
+}
+
+impl SoundGenerator<f32> for SinGenerator {
+    fn init(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate;
+    }
+    fn handle_event(&mut self, event: f32) {
+        self.frequency = event;
+        App::print(format!("new frequency: {}\n", event));
+    }
+    fn next_value(&mut self) -> f32 {
+        if self.channel == 1 {
+            self.i += 1;
+            self.channel = 0;
+        } else {
+            self.channel = 1;
+        }
+        ((self.i as f32 % self.sample_rate) * self.frequency * 2.0 * 3.14159 / self.sample_rate)
+            .sin() * self.volume
+    }
+}
+
+struct SoundEngine {
+    driver: SoundDriver<f32>,
+    frequency: f32,
+}
+
+impl SoundEngine {
+    pub fn new() -> Box<Actor> {
+        Box::new(Self {
+            driver: SoundDriver::new(Box::new(SinGenerator::new(0.2))),
+            frequency: 440.0,
+        })
+    }
+}
+
+impl Actor for SoundEngine {
+    fn start(&mut self, _go: &mut GameObject, world: &mut World) {
+        self.driver.start();
+        // add main camera to scene
+        {
+            let go = world.new_game_object();
+            go.borrow_mut().add_component(Camera::default());
+        }
+    }
+    fn update(&mut self, _go: &mut GameObject, world: &mut World) {
+        self.driver.frame();
+        for evt in world.events().iter() {
+            match evt {
+                &AppEvent::Click(_) => {
+                    self.frequency = 600.0 - self.frequency;
+                    App::print(format!("sending new frequency event: {}\n", self.frequency));
+                    self.driver.send_event(self.frequency);
+                }
+                _ => (),
+            }
+        }
+        // GUI
+        use imgui::Metric::*;
+        imgui::label(
+            Native(0.5, 0.5),
+            "Click of the canvas\nto change the sound frequency",
+        );
+    }
+}
+
+pub fn main() {
+    let mut world = WorldBuilder::new("Sound demo")
+        .with_size((640, 480))
+        .with_stats(true)
+        .build();
+
+    // Add the main scene as component of scene game object
+    let scene = world.new_game_object();
+    scene.borrow_mut().add_component(SoundEngine::new());
+    drop(scene);
+
+    world.event_loop();
+}

--- a/uni-snd/Cargo.toml
+++ b/uni-snd/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "uni-snd"
+version = "0.1.0"
+authors = ["jice <jice.nospam@gmail.com>"]
+
+[dependencies]
+uni-app={path="../../unrust/uni-app"}
+[target.wasm32-unknown-unknown.dependencies]
+stdweb =  "0.4.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cpal="0.8"

--- a/uni-snd/src/lib.rs
+++ b/uni-snd/src/lib.rs
@@ -21,6 +21,14 @@ pub mod snd;
 
 pub use self::snd::*;
 
+#[derive(Debug,Clone,Copy)]
+pub enum SoundError {
+    NoError,
+    NoDevice,
+    OutputStream,
+    UnknownStreamFormat,
+}
+
 pub trait SoundGenerator<T>: Send {
     fn init(&mut self, sample_rate: f32);
     fn handle_event(&mut self, evt: T);

--- a/uni-snd/src/lib.rs
+++ b/uni-snd/src/lib.rs
@@ -1,0 +1,28 @@
+#![recursion_limit = "256"]
+
+extern crate uni_app;
+
+// wasm-unknown-unknown
+#[cfg(target_arch = "wasm32")]
+#[macro_use]
+extern crate stdweb;
+
+#[cfg(target_arch = "wasm32")]
+#[path = "web_snd.rs"]
+pub mod snd;
+
+// NOT wasm-unknown-unknown
+#[cfg(not(target_arch = "wasm32"))]
+extern crate cpal;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "native_snd.rs"]
+pub mod snd;
+
+pub use self::snd::*;
+
+pub trait SoundGenerator<T>: Send {
+    fn init(&mut self, sample_rate: f32);
+    fn handle_event(&mut self, evt: T);
+    fn next_value(&mut self) -> f32;
+}

--- a/uni-snd/src/native_snd.rs
+++ b/uni-snd/src/native_snd.rs
@@ -104,8 +104,6 @@ impl<T: Send + 'static> SoundDriver<T> {
                     }
                 })
             });
-        } else {
-            App::print("error : no event loop\n");
         }
     }
 }

--- a/uni-snd/src/native_snd.rs
+++ b/uni-snd/src/native_snd.rs
@@ -1,0 +1,111 @@
+use std;
+use std::thread;
+use std::sync::mpsc::{channel, Sender};
+
+use cpal;
+use uni_app::App;
+use super::SoundGenerator;
+
+pub struct SoundDriver<T: Send + 'static> {
+    event_loop: Option<cpal::EventLoop>,
+    format: Option<cpal::Format>,
+    stream_id: Option<cpal::StreamId>,
+    tx: Option<Sender<T>>,
+    generator: Option<Box<SoundGenerator<T>>>,
+}
+
+impl<T: Send + 'static> SoundDriver<T> {
+    pub fn new(generator: Box<SoundGenerator<T>>) -> Self {
+        let device = cpal::default_output_device();
+        let mut event_loop = None;
+        let mut format = None;
+        let mut stream_id = None;
+        if let Some(ref dev) = device {
+            match dev.default_output_format() {
+                Ok(fmt) => {
+                    let evt = cpal::EventLoop::new();
+                    match evt.build_output_stream(dev, &fmt) {
+                        Ok(str) => stream_id = Some(str),
+                        Err(e) => {
+                            App::print(format!("error : could not build output stream : {}\n", e))
+                        }
+                    }
+                    App::print(format!(
+                        "sound device : {} format {:?}\n",
+                        dev.name(),
+                        fmt.clone()
+                    ));
+                    format = Some(fmt);
+                    event_loop = Some(evt);
+                }
+                Err(e) => App::print(format!(
+                    "error : could not get default output format : {:?}\n",
+                    e
+                )),
+            }
+        } else {
+            App::print("warning : no sound device detected\n");
+        }
+        Self {
+            event_loop,
+            format,
+            stream_id,
+            tx: None,
+            generator: Some(generator),
+        }
+    }
+    pub fn send_event(&mut self, event: T) {
+        if let Some(ref mut tx) = self.tx {
+            tx.send(event).unwrap();
+        }
+    }
+    fn get_sample_rate(&self) -> f32 {
+        if let Some(ref fmt) = self.format {
+            fmt.sample_rate.0 as f32
+        } else {
+            1.0
+        }
+    }
+    pub fn frame(&mut self) {}
+    pub fn start(&mut self) {
+        let (tx, rx) = channel();
+        self.tx = Some(tx);
+        let stream_id = self.stream_id.take().unwrap();
+        let sample_rate = self.get_sample_rate();
+        let mut generator = self.generator.take().unwrap();
+        if let Some(evt) = self.event_loop.take() {
+            thread::spawn(move || {
+                App::print("starting audio loop\n");
+                evt.play_stream(stream_id);
+                generator.init(sample_rate);
+                evt.run(move |_stream_id, stream_data| {
+                    for event in rx.try_iter() {
+                        generator.handle_event(event);
+                    }
+
+                    match stream_data {
+                        cpal::StreamData::Output {
+                            buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer),
+                        } => for elem in buffer.iter_mut() {
+                            *elem = ((generator.next_value() * 0.5 + 0.5) * std::u16::MAX as f32)
+                                as u16;
+                        },
+                        cpal::StreamData::Output {
+                            buffer: cpal::UnknownTypeOutputBuffer::I16(mut buffer),
+                        } => for elem in buffer.iter_mut() {
+                            *elem = (generator.next_value() * std::i16::MAX as f32) as i16;
+                        },
+                        cpal::StreamData::Output {
+                            buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer),
+                        } => for elem in buffer.iter_mut() {
+                            *elem = generator.next_value();
+                        },
+                        _ => App::print(format!("unsupported stream data\n")),
+                    }
+                })
+            });
+        } else {
+            App::print("error : no event loop\n");
+        }
+    }
+}

--- a/uni-snd/src/native_snd.rs
+++ b/uni-snd/src/native_snd.rs
@@ -100,7 +100,7 @@ impl<T: Send + 'static> SoundDriver<T> {
                         } => for elem in buffer.iter_mut() {
                             *elem = generator.next_value();
                         },
-                        _ => App::print(format!("unsupported stream data\n")),
+                        _ => panic!("unsupported stream data"),
                     }
                 })
             });

--- a/uni-snd/src/web_snd.rs
+++ b/uni-snd/src/web_snd.rs
@@ -1,0 +1,89 @@
+use stdweb;
+use stdweb::unstable::TryInto;
+use stdweb::web::TypedArray;
+
+use uni_app::App;
+
+use super::SoundGenerator;
+
+pub struct SoundDriver<T> {
+    generator: Option<Box<SoundGenerator<T>>>,
+    ctx: stdweb::Value,
+    start_audio: f64,
+    buffer: [f32; BUFFER_SIZE as usize * 2],
+}
+
+const BUFFER_SIZE: u32 = 2048;
+const AUDIO_LATENCY: f64 = 0.1;
+
+impl<T> SoundDriver<T> {
+    pub fn new(generator: Box<SoundGenerator<T>>) -> Self {
+        let ctx = js! {
+            if (AudioContext) {
+                return new AudioContext();
+            } else {
+                return undefined;
+            }
+        };
+        Self {
+            generator: Some(generator),
+            ctx,
+            start_audio: 0.0,
+            buffer: [0.0; BUFFER_SIZE as usize * 2],
+        }
+    }
+    pub fn send_event(&mut self, event: T) {
+        if let Some(ref mut gen) = self.generator {
+            gen.handle_event(event);
+        }
+    }
+    pub fn frame(&mut self) {
+        let now: f64 = js! {
+            return @{&self.ctx}.currentTime;
+        }.try_into()
+            .unwrap();
+        let now_latency = now + AUDIO_LATENCY;
+        if self.start_audio == 0.0 {
+            self.start_audio = now_latency;
+        }
+        if now >= self.start_audio - AUDIO_LATENCY {
+            if let Some(ref mut gen) = self.generator {
+                for i in 0..BUFFER_SIZE as usize * 2 {
+                    self.buffer[i] = gen.next_value();
+                }
+            }
+            let typed_array: TypedArray<f32> = (&self.buffer[..]).into();
+            let samples: f64 = js! {
+                var buffer=@{&self.ctx}.createBuffer(2,@{BUFFER_SIZE},@{&self.ctx}.sampleRate);
+                var channel0 = buffer.getChannelData(0);
+                var channel1 = buffer.getChannelData(1);
+                var obuf=@{typed_array};
+                for (var i=0,j=0; i < @{BUFFER_SIZE}; i++) {
+                    channel0[i] = obuf[j++];
+                    channel1[i] = obuf[j++];
+                }
+                var bufferSource = @{&self.ctx}.createBufferSource();
+                bufferSource.buffer = buffer;
+                bufferSource.connect(@{&self.ctx}.destination);
+                bufferSource.start(@{&self.start_audio});
+                var bufferSec = @{BUFFER_SIZE} / @{&self.ctx}.sampleRate;
+                return bufferSec;
+            }.try_into()
+                .unwrap();
+            self.start_audio += samples;
+        }
+    }
+    pub fn start(&mut self) {
+        if let Some(ref mut gen) = self.generator {
+            let sample_rate: f64 = js!{
+                return @{&self.ctx}.sampleRate;
+            }.try_into()
+                .unwrap();
+            App::print(format!(
+                "sound device : Web audio context. sample_rate: {}\n",
+                sample_rate
+            ));
+            gen.init(sample_rate as f32);
+        }
+    }
+}

--- a/webgl/src/webgl.rs
+++ b/webgl/src/webgl.rs
@@ -676,7 +676,7 @@ impl GLContext {
         }
     }
 
-    pub fn uniform_1fv(&self, location: &WebGLUniformLocation, count: usize, value: &[f32]) {
+    pub fn uniform_1fv(&self, location: &WebGLUniformLocation, _count: usize, value: &[f32]) {
         js!{
             var ctx = Module.gl.get(@{self.reference});
             var loc = Module.gl.get(@{location.deref()});


### PR DESCRIPTION
Ok this is a bit involved and should be considered a first draft.
It only covers the lower uni-snd layer and not its integration into the unrust engine. I hacked a sound example to demonstrate how to use the uni-snd library, not how to properly integrate it in unrust.

There's a SoundDriver that has a very different behavior in native and web.

On the native side, it starts a detached thread and sends data to the audio interface, pulling it from the provided SoundGenerator.next_value function.
Since the SoundGenerator is owned by the thread, you cannot keep a reference and call methods on it. instead, you have to use the SoundDriver.send_event method to send messages through a channel.

On the web side, the frame function should be called every frame so that it keeps the audio buffer filled.

Right now, stereo mode is hardcoded and the sound generator should alternatively provide the left and right channels values.