### PR TITLE
gamepad support (web only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uni-pad"
+version = "0.1.0"
+dependencies = [
+ "stdweb 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uni-app 0.1.0",
+]
+
+[[package]]
 name = "uni-snd"
 version = "0.1.0"
 dependencies = [
@@ -1101,6 +1109,7 @@ dependencies = [
  "obj 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uni-app 0.1.0",
  "uni-glsl 0.1.0",
+ "uni-pad 0.1.0",
  "uni-snd 0.1.0",
  "webgl 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ webgl = {path="webgl"}
 uni-app = {path="uni-app"}
 uni-glsl = {path="uni-glsl"}
 uni-snd = {path="uni-snd"}
+uni-pad = {path="uni-pad"}
 futures = "0.1"
 obj = "0.8.2"
 bitflags = "1.0"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,3 +1,4 @@
+extern crate uni_pad;
 extern crate unrust;
 
 use unrust::world::{Actor, World, WorldBuilder};
@@ -5,6 +6,7 @@ use unrust::engine::{Directional, GameObject, Light, Material, Mesh};
 use unrust::world::events::*;
 use unrust::math::*;
 use unrust::actors::FirstPersonCamera;
+use uni_pad::{gamepad_axis, gamepad_button};
 
 // GUI
 use unrust::imgui;
@@ -97,7 +99,12 @@ impl Actor for MainScene {
         imgui::pivot((1.0, 1.0));
         imgui::label(
             Native(1.0, 1.0) - Pixel(8.0, 8.0),
-            "[WASD ZXEC] : control camera\n[Esc] : reload all (include assets)",
+            &format!("[WASD ZXEC] : control camera\n[Esc] : reload all (include assets)\ngamepad: {:?} buttons {} {} {} {}",
+                gamepad_axis(0),
+                gamepad_button(0, 0),
+                gamepad_button(0, 1),
+                gamepad_button(0, 2),
+                gamepad_button(0, 3))
         );
 
         imgui::pivot((1.0, 0.0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate image;
 extern crate obj;
 extern crate uni_app;
 extern crate uni_glsl;
+extern crate uni_pad;
 extern crate uni_snd;
 extern crate webgl;
 

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -15,6 +15,7 @@ use world::Actor;
 use world::processor::{IProcessorBuilder, Processor};
 
 use uni_app::{now, App, AppConfig, AppEvent};
+use uni_pad as pad;
 use std::default::Default;
 use std::marker::PhantomData;
 
@@ -97,6 +98,8 @@ impl<'a> WorldBuilder<'a> {
         );
         let events = app.events.clone();
         let main_tree = engine.new_scene_tree();
+
+        pad::gamepad_init();
 
         let watcher = self.watcher_builder
             .add_watcher(ActorWatcher::<Box<Actor>>::new())

--- a/uni-pad/Cargo.toml
+++ b/uni-pad/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uni-pad"
+version = "0.1.0"
+authors = ["jice <jice.nospam@gmail.com>"]
+
+[dependencies]
+uni-app={path="../../unrust/uni-app"}
+[target.wasm32-unknown-unknown.dependencies]
+stdweb =  "0.4.1"

--- a/uni-pad/src/lib.rs
+++ b/uni-pad/src/lib.rs
@@ -1,0 +1,18 @@
+#![feature(nll)]
+#![recursion_limit = "512"]
+
+// wasm-unknown-unknown
+#[cfg(target_arch = "wasm32")]
+#[macro_use]
+extern crate stdweb;
+
+#[cfg(target_arch = "wasm32")]
+#[path = "web_pad.rs"]
+pub mod pad;
+
+// NOT wasm-unknown-unknown
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "native_pad.rs"]
+pub mod pad;
+
+pub use self::pad::*;

--- a/uni-pad/src/native_pad.rs
+++ b/uni-pad/src/native_pad.rs
@@ -1,0 +1,10 @@
+// TODO
+pub fn gamepad_init() {}
+
+pub fn gamepad_axis(_player_num: i32) -> (f32, f32) {
+    (0.0, 0.0)
+}
+
+pub fn gamepad_button(_player_num: i32, _button_num: i32) -> bool {
+    false
+}

--- a/uni-pad/src/web_pad.rs
+++ b/uni-pad/src/web_pad.rs
@@ -1,0 +1,75 @@
+use stdweb::unstable::TryInto;
+
+pub fn gamepad_init() {
+    js! {
+        window.pads=[];
+        if (navigator.getGamepads === undefined) {
+            console.log("warning : no gamepad support on this browser");
+        } else {
+            window.addEventListener("gamepadconnected", function(e) {
+                if (e.gamepad) {
+                    console.log("gamepad["+e.gamepad.index+"] id "+e.gamepad.id+" connected.");
+                    window.pads[e.gamepad.index] = e.gamepad;
+                }
+            });
+            window.addEventListener("gamepaddisconnected", function(e) {
+                if (e.gamepad) {
+                    console.log("gamepad["+e.gamepad.index+"] id "+e.gamepad.id+" disconnected.");
+                    window.pads[e.gamepad.index] = undefined;
+                }
+            });
+        }
+    };
+}
+
+pub fn gamepad_axis(player_num: i32) -> (f32, f32) {
+    let x: f64 = js! {
+        if (navigator.userAgent.toLowerCase().indexOf("chrome") != -1) {
+            var gp = navigator.getGamepads();
+            for (var i=0; i < gp.length; i++) {
+                if (gp[i]!=null) {
+                    window.pads[gp[i].index]=gp[i];
+                }
+            }
+        }
+        if ( window.pads[@{player_num}] ) {
+            return window.pads[@{player_num}].axes[0];
+        } else {
+            return 0.0;
+        }
+    }.try_into()
+        .unwrap();
+    let y: f64 = js! {
+        if ( window.pads[@{player_num}] ) {
+            return window.pads[@{player_num}].axes[1];
+        } else {
+            return 0.0;
+        }
+    }.try_into()
+        .unwrap();
+    (x as f32, y as f32)
+}
+pub fn gamepad_button(player_num: i32, button_num: i32) -> bool {
+    let ret = js! {
+        if (navigator.userAgent.toLowerCase().indexOf("chrome") != -1) {
+            var gp = navigator.getGamepads();
+            for (var i=0; i < gp.length; i++) {
+                if (gp[i]!=null) {
+                    window.pads[gp[i].index]=gp[i];
+                }
+            }
+        }
+        if ( window.pads[@{player_num}] ) {
+            var button = window.pads[@{player_num}].buttons[@{button_num}];
+            if (typeof button == "object") {
+                return button.pressed;
+            } else {
+                return button == 1.0;
+            }
+        } else {
+            return false;
+        }
+    }.try_into()
+        .unwrap();
+    ret
+}


### PR DESCRIPTION
This is not integrated with unrust yet as it requires a refactoring of FirstPersonCamera which relies only on keyboard right now. You can check usage in the basic example.
I've tested it with an XBox gamepad on firefox and chrome. Support to more pads/browsers/os might need some tweaks.